### PR TITLE
PR#8 AsyncThunk作成とローカルストレージ保存機能追加

### DIFF
--- a/src/components/page/hooks/useMainPage.tsx
+++ b/src/components/page/hooks/useMainPage.tsx
@@ -21,7 +21,7 @@ export const useMainPage = () => {
   const searchText = useSelector(searchTextSelector);
 
   useEffect(() => {
-    // 初回マウント時、ローカルストレージに保存してるクリップをセットする
+    // 初回マウント時、ローカルストレージに保存してるクリップを取得しstoreへセット
     dispatch(fetchAllClips());
   }, []);
 

--- a/src/components/page/hooks/useMainPage.tsx
+++ b/src/components/page/hooks/useMainPage.tsx
@@ -2,7 +2,12 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Clip } from 'src/entity/clip';
 import { AppDispatch } from 'src/store';
-import { fetchAllClips, setStorageClips } from 'src/store/clip.async-thunks';
+import {
+  addNewClip,
+  deleteClip,
+  editedClip,
+  fetchAllClips,
+} from 'src/store/clip.async-thunks';
 import {
   clipsSelector,
   searchedClipSelector,
@@ -25,13 +30,9 @@ export const useMainPage = () => {
     dispatch(fetchAllClips());
   }, []);
 
-  useEffect(() => {
-    dispatch(setStorageClips(clips));
-  }, [clips]);
-
   // 新規クリップ追加
   const handleAddClip = () => {
-    dispatch(clipActions.addClip());
+    dispatch(addNewClip());
   };
 
   // クリップ選択
@@ -40,12 +41,12 @@ export const useMainPage = () => {
   };
   // クリップ削除
   const handleDeleteClip = () => {
-    selectedClip && dispatch(clipActions.deleteClip(selectedClip.id));
+    selectedClip && dispatch(deleteClip(selectedClip.id));
   };
 
   // テキスト保存
   const handleSaveText = (editClip: Clip) => {
-    dispatch(clipActions.editClip(editClip));
+    dispatch(editedClip(editClip));
   };
 
   // 検索テキスト

--- a/src/components/page/hooks/useMainPage.tsx
+++ b/src/components/page/hooks/useMainPage.tsx
@@ -1,5 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { Clip } from 'src/entity/clip';
+import { AppDispatch } from 'src/store';
+import { fetchAllClips } from 'src/store/clip.async-thunks';
 import {
   clipsSelector,
   searchedClipSelector,
@@ -10,7 +12,7 @@ import { clipActions } from 'src/store/clip.slice';
 
 export const useMainPage = () => {
   // store関連
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
 
   const clips = useSelector(clipsSelector);
   const selectedClip = useSelector(selectedClipSelector);
@@ -20,6 +22,7 @@ export const useMainPage = () => {
   // 新規クリップ追加
   const handleAddClip = () => {
     dispatch(clipActions.addClip());
+    dispatch(fetchAllClips());
   };
 
   // クリップ選択

--- a/src/components/page/hooks/useMainPage.tsx
+++ b/src/components/page/hooks/useMainPage.tsx
@@ -1,7 +1,8 @@
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Clip } from 'src/entity/clip';
 import { AppDispatch } from 'src/store';
-import { fetchAllClips } from 'src/store/clip.async-thunks';
+import { fetchAllClips, setStorageClips } from 'src/store/clip.async-thunks';
 import {
   clipsSelector,
   searchedClipSelector,
@@ -19,10 +20,18 @@ export const useMainPage = () => {
   const searchedClip = useSelector(searchedClipSelector);
   const searchText = useSelector(searchTextSelector);
 
+  useEffect(() => {
+    // 初回マウント時、ローカルストレージに保存してるクリップをセットする
+    dispatch(fetchAllClips());
+  }, []);
+
+  useEffect(() => {
+    dispatch(setStorageClips(clips));
+  }, [clips]);
+
   // 新規クリップ追加
   const handleAddClip = () => {
     dispatch(clipActions.addClip());
-    dispatch(fetchAllClips());
   };
 
   // クリップ選択

--- a/src/components/shared/contents/ContentsHeader.tsx
+++ b/src/components/shared/contents/ContentsHeader.tsx
@@ -8,6 +8,7 @@ import {
 import { Flex } from 'antd';
 import { Header } from 'antd/lib/layout/layout';
 import React, { FC } from 'react';
+import removeMd from 'remove-markdown';
 
 import { ContentsHeaderActions } from '@/components/ui/contents/ContentsHeaderActions';
 import { ContentsHeaderTitle } from '@/components/ui/contents/ContentsHeaderTitle';
@@ -28,7 +29,7 @@ export const ContentsHeader: FC<PropsType> = ({
     <Header className="top-0 right-0 border-b-2 fixed bg-white left-80 min-w-96 z-50 items-center">
       {title ? (
         <Flex align="center" justify="space-between">
-          <ContentsHeaderTitle title={title} />
+          <ContentsHeaderTitle title={removeMd(title)} />
           <ContentsHeaderActions>
             <Flex
               className="cursor-pointer"

--- a/src/components/shared/sidebar/SideBarContents.tsx
+++ b/src/components/shared/sidebar/SideBarContents.tsx
@@ -35,42 +35,43 @@ export const SideBarContents: FC<SideBarContentsPropsType> = ({
   return (
     <>
       <div className="mt-20">
-        {cliplist.map((clip) => {
-          return (
-            <>
-              <ClipLayout
-                isSelect={selectedClipId == clip.id}
-                key={clip.id}
-                onClick={() => onSelectClip(clip.id)}
-              >
-                <ClipTitleText>
-                  {clip.title ? removeMd(clip.title) : 'ステキな新しいメモ'}
-                </ClipTitleText>
-                <p className="line-clamp-2 w-full">
-                  {clip.title
-                    ? removeMd(clip.text)
-                    : '落ち着いて、何か書いてみましょう'}
-                </p>
-
-                <Flex
-                  align="center"
-                  className="w-full mt-5 mb-3"
-                  justify="space-between"
+        {cliplist &&
+          cliplist.map((clip) => {
+            return (
+              <>
+                <ClipLayout
+                  isSelect={selectedClipId == clip.id}
+                  key={clip.id}
+                  onClick={() => onSelectClip(clip.id)}
                 >
-                  <p className="text-xs">
-                    {clip.updateAt
-                      ? displayDateFormat(clip.updateAt)
-                      : displayDateFormat(clip.createdAt)}
+                  <ClipTitleText>
+                    {clip.title ? removeMd(clip.title) : 'ステキな新しいメモ'}
+                  </ClipTitleText>
+                  <p className="line-clamp-2 w-full">
+                    {clip.title
+                      ? removeMd(clip.text)
+                      : '落ち着いて、何か書いてみましょう'}
                   </p>
-                  <DeleteOutlined
-                    className="text-base"
-                    onClick={() => setIsModalOpen(true)}
-                  />
-                </Flex>
-              </ClipLayout>
-            </>
-          );
-        })}
+
+                  <Flex
+                    align="center"
+                    className="w-full mt-5 mb-3"
+                    justify="space-between"
+                  >
+                    <p className="text-xs">
+                      {clip.updateAt
+                        ? displayDateFormat(clip.updateAt)
+                        : displayDateFormat(clip.createdAt)}
+                    </p>
+                    <DeleteOutlined
+                      className="text-base"
+                      onClick={() => setIsModalOpen(true)}
+                    />
+                  </Flex>
+                </ClipLayout>
+              </>
+            );
+          })}
       </div>
       <BaseModal
         handleCancel={() => setIsModalOpen(false)}

--- a/src/lib/clips.repository.ts
+++ b/src/lib/clips.repository.ts
@@ -1,21 +1,18 @@
 import { Clip } from 'src/entity/clip';
 
 export interface IClipsRepository {
-  /**
-   * ログイン済みユーザーの取得
-   */
-  setClip(): Promise<Clip>;
+  getAllClips(): Promise<Clip[]>;
+  setClip(clips: Clip[]): Promise<void>;
 }
 
 export class ClipsRepository implements IClipsRepository {
-  async setClip() {
-    const newClip = {
-      createdAt: '',
-      id: 0,
-      text: '',
-      title: '',
-    };
-    localStorage.setItem(`${newClip.id}`, JSON.stringify(newClip));
-    return newClip;
+  async setClip(clips: Clip[]) {
+    localStorage.setItem(`clips`, JSON.stringify(clips));
+    return;
+  }
+  async getAllClips() {
+    const clipsJson = localStorage.getItem(`clips`);
+    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+    return clips;
   }
 }

--- a/src/lib/clips.repository.ts
+++ b/src/lib/clips.repository.ts
@@ -1,0 +1,21 @@
+import { Clip } from 'src/entity/clip';
+
+export interface IClipsRepository {
+  /**
+   * ログイン済みユーザーの取得
+   */
+  setClip(): Promise<Clip>;
+}
+
+export class ClipsRepository implements IClipsRepository {
+  async setClip() {
+    const newClip = {
+      createdAt: '',
+      id: 0,
+      text: '',
+      title: '',
+    };
+    localStorage.setItem(`${newClip.id}`, JSON.stringify(newClip));
+    return newClip;
+  }
+}

--- a/src/lib/clips.repository.ts
+++ b/src/lib/clips.repository.ts
@@ -10,17 +10,11 @@ export interface IClipsRepository {
 
 export class ClipsRepository implements IClipsRepository {
   async getAllClips() {
-    // STRAT==ここの処理共通化していいものなんですかね
-    const clipsJson = localStorage.getItem(`clips`);
-    const clips = clipsJson ? JSON.parse(clipsJson) : [];
-    // ===END
-
-    return clips;
+    return this.getStorageClips();
   }
 
   async addClip() {
-    const clipsJson = localStorage.getItem(`clips`);
-    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+    const clips = this.getStorageClips();
 
     const createdAt = nowDate();
     const clipId = clips.length > 0 ? clips[clips.length - 1].id : 0;
@@ -32,30 +26,41 @@ export class ClipsRepository implements IClipsRepository {
       title: '',
     };
     const newClips = [...clips, newClip];
-    localStorage.setItem(`clips`, JSON.stringify(newClips));
+    this.setStorageClips(newClips);
     return newClips;
   }
 
   async editClip(editedClip: Clip) {
-    const clipsJson = localStorage.getItem(`clips`);
-    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+    const clips = this.getStorageClips();
 
     const newClips = clips.map((clip: Clip) =>
       clip.id === editedClip.id ? editedClip : clip,
     );
-    localStorage.setItem(`clips`, JSON.stringify(newClips));
+    this.setStorageClips(newClips);
     return newClips;
   }
 
   async deleteClip(clipId: number) {
-    const clipsJson = localStorage.getItem(`clips`);
-    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+    const clips = this.getStorageClips();
 
     const deletedClips = clips.filter(
       (clip: { id: number }) => clip.id !== clipId,
     );
 
-    localStorage.setItem(`clips`, JSON.stringify(deletedClips));
+    this.setStorageClips(deletedClips);
     return deletedClips;
+  }
+
+  // storageからClip情報を取得
+  private getStorageClips() {
+    const clipsJson = localStorage.getItem(`clips`);
+    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+    return clips;
+  }
+
+  // storageにClip情報を格納
+  private setStorageClips(clips: Clip[]) {
+    localStorage.setItem(`clips`, JSON.stringify(clips));
+    return;
   }
 }

--- a/src/lib/clips.repository.ts
+++ b/src/lib/clips.repository.ts
@@ -1,18 +1,61 @@
 import { Clip } from 'src/entity/clip';
+import { nowDate } from 'src/utils/day';
 
 export interface IClipsRepository {
+  addClip(): Promise<Clip[]>;
+  deleteClip(clipId: number): Promise<Clip[]>;
+  editClip(clip: Clip): Promise<Clip[]>;
   getAllClips(): Promise<Clip[]>;
-  setClip(clips: Clip[]): Promise<void>;
 }
 
 export class ClipsRepository implements IClipsRepository {
-  async setClip(clips: Clip[]) {
-    localStorage.setItem(`clips`, JSON.stringify(clips));
-    return;
-  }
   async getAllClips() {
+    // STRAT==ここの処理共通化していいものなんですかね
     const clipsJson = localStorage.getItem(`clips`);
     const clips = clipsJson ? JSON.parse(clipsJson) : [];
+    // ===END
+
     return clips;
+  }
+
+  async addClip() {
+    const clipsJson = localStorage.getItem(`clips`);
+    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+
+    const createdAt = nowDate();
+    const clipId = clips.length > 0 ? clips[clips.length - 1].id : 0;
+
+    const newClip = {
+      createdAt: createdAt,
+      id: clipId + 1,
+      text: '',
+      title: '',
+    };
+    const newClips = [...clips, newClip];
+    localStorage.setItem(`clips`, JSON.stringify(newClips));
+    return newClips;
+  }
+
+  async editClip(editedClip: Clip) {
+    const clipsJson = localStorage.getItem(`clips`);
+    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+
+    const newClips = clips.map((clip: Clip) =>
+      clip.id === editedClip.id ? editedClip : clip,
+    );
+    localStorage.setItem(`clips`, JSON.stringify(newClips));
+    return newClips;
+  }
+
+  async deleteClip(clipId: number) {
+    const clipsJson = localStorage.getItem(`clips`);
+    const clips = clipsJson ? JSON.parse(clipsJson) : [];
+
+    const deletedClips = clips.filter(
+      (clip: { id: number }) => clip.id !== clipId,
+    );
+
+    localStorage.setItem(`clips`, JSON.stringify(deletedClips));
+    return deletedClips;
   }
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './repositories';
+export * from './clips.repository';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,0 @@
-export * from './repositories';
-export * from './clips.repository';

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,0 +1,28 @@
+import { ClipsRepository, IClipsRepository } from 'src/lib';
+
+interface IRepositories {
+  clips: IClipsRepository;
+}
+
+class Repositories implements IRepositories {
+  private static instance: IRepositories;
+  readonly clips: IClipsRepository;
+
+  constructor(repositories: IRepositories) {
+    const { clips } = repositories;
+    this.clips = clips;
+  }
+
+  static getInstance() {
+    if (!Repositories.instance) {
+      const clips = new ClipsRepository();
+      // Repositories.instance = new Repositories({
+      //   clips,
+      // });
+    }
+    return Repositories.instance;
+  }
+}
+
+export const repositories = Repositories.getInstance();
+// export const clipsRepository = repositories.clips;

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,4 +1,4 @@
-import { ClipsRepository, IClipsRepository } from 'src/lib';
+import { ClipsRepository, IClipsRepository } from 'src/lib/clips.repository';
 
 interface IRepositories {
   clips: IClipsRepository;
@@ -16,13 +16,12 @@ class Repositories implements IRepositories {
   static getInstance() {
     if (!Repositories.instance) {
       const clips = new ClipsRepository();
-      // Repositories.instance = new Repositories({
-      //   clips,
-      // });
+      Repositories.instance = new Repositories({
+        clips,
+      });
     }
     return Repositories.instance;
   }
 }
 
 export const repositories = Repositories.getInstance();
-// export const clipsRepository = repositories.clips;

--- a/src/store/clip.async-thunks.ts
+++ b/src/store/clip.async-thunks.ts
@@ -3,15 +3,30 @@ import { Clip } from 'src/entity/clip';
 import { repositories } from 'src/lib/repositories';
 import { CLIP_FEATURE_KEY } from 'src/store/clip.state';
 
-export const setStorageClips = createAsyncThunk(
-  `${CLIP_FEATURE_KEY}/addClips`,
-  async (clips: Clip[]) => {
-    return repositories.clips.setClip(clips);
-  },
-);
 export const fetchAllClips = createAsyncThunk(
   `${CLIP_FEATURE_KEY}/getClips`,
   async () => {
     return repositories.clips.getAllClips();
+  },
+);
+
+export const addNewClip = createAsyncThunk(
+  `${CLIP_FEATURE_KEY}/addClip`,
+  async () => {
+    return repositories.clips.addClip();
+  },
+);
+
+export const editedClip = createAsyncThunk(
+  `${CLIP_FEATURE_KEY}/editClip`,
+  async (clip: Clip) => {
+    return repositories.clips.editClip(clip);
+  },
+);
+
+export const deleteClip = createAsyncThunk(
+  `${CLIP_FEATURE_KEY}/deleteClip`,
+  async (clipId: number) => {
+    return repositories.clips.deleteClip(clipId);
   },
 );

--- a/src/store/clip.async-thunks.ts
+++ b/src/store/clip.async-thunks.ts
@@ -1,0 +1,18 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { repositories } from 'src/lib';
+import { CLIP_FEATURE_KEY } from 'src/store/clip.state';
+
+// export const fetchAllClips = createAsyncThunk(
+//   `${CLIP_FEATURE_KEY}/fetchClips`,
+//   async () => {
+//     return repositories.users.getLoggedInUser();
+//   },
+// );
+
+export const fetchAllClips = createAsyncThunk(
+  `${CLIP_FEATURE_KEY}/addClips`,
+  async () => {
+    return repositories.clips.setClip();
+    // return clipsRepository.setClip();
+  },
+);

--- a/src/store/clip.async-thunks.ts
+++ b/src/store/clip.async-thunks.ts
@@ -1,18 +1,17 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { repositories } from 'src/lib';
+import { Clip } from 'src/entity/clip';
+import { repositories } from 'src/lib/repositories';
 import { CLIP_FEATURE_KEY } from 'src/store/clip.state';
 
-// export const fetchAllClips = createAsyncThunk(
-//   `${CLIP_FEATURE_KEY}/fetchClips`,
-//   async () => {
-//     return repositories.users.getLoggedInUser();
-//   },
-// );
-
-export const fetchAllClips = createAsyncThunk(
+export const setStorageClips = createAsyncThunk(
   `${CLIP_FEATURE_KEY}/addClips`,
+  async (clips: Clip[]) => {
+    return repositories.clips.setClip(clips);
+  },
+);
+export const fetchAllClips = createAsyncThunk(
+  `${CLIP_FEATURE_KEY}/getClips`,
   async () => {
-    return repositories.clips.setClip();
-    // return clipsRepository.setClip();
+    return repositories.clips.getAllClips();
   },
 );

--- a/src/store/clip.slice.ts
+++ b/src/store/clip.slice.ts
@@ -1,41 +1,20 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Clip } from 'src/entity/clip';
-import { fetchAllClips } from 'src/store/clip.async-thunks';
+import {
+  addNewClip,
+  deleteClip,
+  editedClip,
+  fetchAllClips,
+} from 'src/store/clip.async-thunks';
 import {
   CLIP_FEATURE_KEY,
   clipAdapter,
   initialClipsState,
 } from 'src/store/clip.state';
-import { nowDate } from 'src/utils/day';
 
 export const clipSlice = createSlice({
   initialState: initialClipsState,
   name: CLIP_FEATURE_KEY,
   reducers: {
-    // 新規追加
-    addClip(state) {
-      state.createdId += 1;
-      const clipId = state.createdId;
-      const createdAt = nowDate();
-
-      const newClip = {
-        createdAt: createdAt,
-        id: clipId,
-        text: '',
-        title: '',
-      };
-      clipAdapter.addOne(state.clips, newClip);
-    },
-
-    // 削除
-    deleteClip(state, action: PayloadAction<number>) {
-      clipAdapter.removeOne(state.clips, action.payload);
-      state.selectedClipId = null;
-    },
-    // 編集
-    editClip(state, action: PayloadAction<Clip>) {
-      clipAdapter.upsertOne(state.clips, action.payload);
-    },
     // 検索
     searchText(state, action: PayloadAction<string>) {
       state.searchText = action.payload;
@@ -47,11 +26,24 @@ export const clipSlice = createSlice({
   },
   // eslint-disable-next-line sort-keys-fix/sort-keys-fix
   extraReducers: (builder) => {
+    // ローカルストレージに保存してるクリップ取得
     builder.addCase(fetchAllClips.fulfilled, (state, action) => {
       const clips = action.payload;
       clipAdapter.setAll(state.clips, clips);
       const id = clips.length > 0 ? clips[clips.length - 1].id : 0;
       state.createdId = id;
+    });
+    // 新規追加
+    builder.addCase(addNewClip.fulfilled, (state, action) => {
+      clipAdapter.setAll(state.clips, action.payload);
+    });
+    // 編集
+    builder.addCase(editedClip.fulfilled, (state, action) => {
+      clipAdapter.setAll(state.clips, action.payload);
+    });
+    // 削除
+    builder.addCase(deleteClip.fulfilled, (state, action) => {
+      clipAdapter.setAll(state.clips, action.payload);
     });
   },
 });

--- a/src/store/clip.slice.ts
+++ b/src/store/clip.slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Clip } from 'src/entity/clip';
-import { fetchAllClips, setStorageClips } from 'src/store/clip.async-thunks';
+import { fetchAllClips } from 'src/store/clip.async-thunks';
 import {
   CLIP_FEATURE_KEY,
   clipAdapter,
@@ -47,9 +47,11 @@ export const clipSlice = createSlice({
   },
   // eslint-disable-next-line sort-keys-fix/sort-keys-fix
   extraReducers: (builder) => {
-    builder.addCase(setStorageClips.fulfilled, () => {});
     builder.addCase(fetchAllClips.fulfilled, (state, action) => {
-      clipAdapter.setAll(state.clips, action.payload);
+      const clips = action.payload;
+      clipAdapter.setAll(state.clips, clips);
+      const id = clips.length > 0 ? clips[clips.length - 1].id : 0;
+      state.createdId = id;
     });
   },
 });

--- a/src/store/clip.slice.ts
+++ b/src/store/clip.slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Clip } from 'src/entity/clip';
-import { fetchAllClips } from 'src/store/clip.async-thunks';
+import { fetchAllClips, setStorageClips } from 'src/store/clip.async-thunks';
 import {
   CLIP_FEATURE_KEY,
   clipAdapter,
@@ -47,6 +47,7 @@ export const clipSlice = createSlice({
   },
   // eslint-disable-next-line sort-keys-fix/sort-keys-fix
   extraReducers: (builder) => {
+    builder.addCase(setStorageClips.fulfilled, () => {});
     builder.addCase(fetchAllClips.fulfilled, (state, action) => {
       clipAdapter.setAll(state.clips, action.payload);
     });

--- a/src/store/clip.slice.ts
+++ b/src/store/clip.slice.ts
@@ -30,8 +30,6 @@ export const clipSlice = createSlice({
     builder.addCase(fetchAllClips.fulfilled, (state, action) => {
       const clips = action.payload;
       clipAdapter.setAll(state.clips, clips);
-      const id = clips.length > 0 ? clips[clips.length - 1].id : 0;
-      state.createdId = id;
     });
     // 新規追加
     builder.addCase(addNewClip.fulfilled, (state, action) => {

--- a/src/store/clip.slice.ts
+++ b/src/store/clip.slice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Clip } from 'src/entity/clip';
+import { fetchAllClips } from 'src/store/clip.async-thunks';
 import {
   CLIP_FEATURE_KEY,
   clipAdapter,
@@ -35,16 +36,20 @@ export const clipSlice = createSlice({
     editClip(state, action: PayloadAction<Clip>) {
       clipAdapter.upsertOne(state.clips, action.payload);
     },
-
     // 検索
     searchText(state, action: PayloadAction<string>) {
       state.searchText = action.payload;
     },
-
     // 選択中クリップ
     selectedClipId(state, action: PayloadAction<number>) {
       state.selectedClipId = action.payload;
     },
+  },
+  // eslint-disable-next-line sort-keys-fix/sort-keys-fix
+  extraReducers: (builder) => {
+    builder.addCase(fetchAllClips.fulfilled, (state, action) => {
+      clipAdapter.setAll(state.clips, action.payload);
+    });
   },
 });
 

--- a/src/store/clip.state.ts
+++ b/src/store/clip.state.ts
@@ -7,14 +7,12 @@ export const clipAdapter = createEntityAdapter<Clip>();
 
 export interface ClipsState {
   clips: EntityState<Clip, number>;
-  createdId: number;
   searchText: string;
   selectedClipId: number | null;
 }
 
 export const initialClipsState: ClipsState = {
   clips: clipAdapter.getInitialState(),
-  createdId: 0,
   searchText: '',
   selectedClipId: null,
 };


### PR DESCRIPTION
今回は非同期通信するものがないので
AsyncThunkを利用して、ローカルストレージに保存する仕様を想定して実装をしています。

## 挙動概要
・クリップのstateに変更があった場合、`setStorageClips` でローカルストレージにクリップ情報を格納しています。
・初回、画面表示時に`fetchAllClips`でローカルストレージに保存したクリップをStoreに格納してます。
<img width="400" alt="スクリーンショット 2024-01-19 11 23 29" src="https://github.com/wada-mitsuki/bear-trace/assets/155605746/c3dfec3e-630e-4ecb-8289-e557b71d1770">
